### PR TITLE
Deduplicate candidates with identical sources via source group IDs

### DIFF
--- a/src/modules/cm-precompute.ts
+++ b/src/modules/cm-precompute.ts
@@ -204,13 +204,12 @@ const listCandidateCount = (ncList: NameCount.List): number => {
     return count;
 };
 
-export const preCompute = (first: number, last: number, args: any): boolean => {
-    const maxSum = last;
+export const preCompute = (args: any): boolean => {
     const merge_only = args.merge_only || false;
 
     const begin = new Date();
     // XOR first
-    const xorNcDataLists = args.xor ? buildAllUseNcDataLists("xor", maxSum, args) : [ [] ];
+    const xorNcDataLists = args.xor ? buildAllUseNcDataLists("xor", args.load_max, args) : [ [] ];
     if (listIsEmpty(xorNcDataLists)) {
        console.error(`empty xorNcDataLists`);
        return false;
@@ -226,7 +225,7 @@ export const preCompute = (first: number, last: number, args: any): boolean => {
     if (merge_only) return true;
 
     // OR next
-    const orNcDataLists = args.or ? buildAllUseNcDataLists("or", maxSum, args) : [ [] ];
+    const orNcDataLists = args.or ? buildAllUseNcDataLists("or", args.load_max, args) : [ [] ];
     if (listIsEmpty(orNcDataLists)) return false;
 
     // TODO: call mergeCompatible here for OR args same as above?

--- a/src/modules/combo-maker.ts
+++ b/src/modules/combo-maker.ts
@@ -331,7 +331,7 @@ export const makeCombos = (args: any): any => {
             });
     } else {
         let totals = ClueManager.emptyFilterResult();
-        const pc_result = PreCompute.preCompute(first, last, args);
+        const pc_result = PreCompute.preCompute(args);
         if (pc_result) {
             // run 2-clue sources synchronously to seed "incompatible sources"
             // which makes subsequent sums faster.

--- a/src/modules/components.ts
+++ b/src/modules/components.ts
@@ -65,10 +65,11 @@ const pre_compute = (name_list: string[], quiet: boolean, options: any): boolean
         merge_only: true,
         min_sources,
         quiet,
+        load_max: options.load_max,
         verbose: options.verbose,
         ignoreErrors: options.ignoreErrors
     };
-    return PreCompute.preCompute(min_sources, options.load_max, pc_args);
+    return PreCompute.preCompute(pc_args);
 }
 
 export const show = (options: any): any => {
@@ -127,10 +128,11 @@ export const consistency_check = (options: any): void => {
                 merge_only: true,
                 max: 2,
                 quiet: true,
+                load_max: options.load_max,
                 verbose: options.verbose,
                 ignoreErrors: options.ignoreErrors
             };
-            valid = PreCompute.preCompute(2, options.load_max, pc_args);
+            valid = PreCompute.preCompute(pc_args);
             if (!valid) {
                 console.error(`\nConsistency::Precompute failed at ${combo}.`);
             }

--- a/src/native-modules/experiment/candidates.cpp
+++ b/src/native-modules/experiment/candidates.cpp
@@ -29,7 +29,8 @@ struct CandidateRepoValue {
   CompatSourceIndicesList compat_src_indices;
   std::optional<int> opt_idx;
 };
-using CandidateRepo = std::unordered_map<std::string, CandidateRepoValue>;
+// key: packed source group ID pair (sorted: lower in high 32 bits)
+using CandidateRepo = std::unordered_map<uint64_t, CandidateRepoValue>;
 
 class Lock {
   Lock() = delete;
@@ -267,8 +268,34 @@ int consider_candidate(int sum, const NameCountCRefList& nc_cref_list,
   const auto& nc2 = nc_cref_list.at(idx_pair.second).get();
   // no lock necessary to modify repo map for a particular sum
   auto& candidate_repo = get_candidate_repo(sum);
-  auto key = NameCount::makeString(nc1, nc2);
-  if (candidate_repo.contains(key)) return 0;
+
+  // key by (count, source_group_id) pairs so names with identical sources
+  // share a candidate. pack count (16 bits) + gid (16 bits) per half.
+  auto gid1 = clue_manager::get_source_group_id(
+      nc1.count, unique_name_indices.at(idx_pair.first));
+  auto gid2 = clue_manager::get_source_group_id(
+      nc2.count, unique_name_indices.at(idx_pair.second));
+  uint32_t cg1 = (uint32_t(nc1.count) << 16) | uint32_t(gid1);
+  uint32_t cg2 = (uint32_t(nc2.count) << 16) | uint32_t(gid2);
+  // sort for consistent key regardless of pair order
+  if (cg1 > cg2) std::swap(cg1, cg2);
+  auto key = (uint64_t(cg1) << 32) | uint64_t(cg2);
+
+  auto combo = NameCount::makeString(nc1.name, nc2.name);
+
+  auto it = candidate_repo.find(key);
+  if (it != candidate_repo.end()) {
+    // source group pair already processed — add combo to existing candidate
+    auto& rv = it->second;
+    if (rv.opt_idx.has_value()) {
+      Lock lk(candidate_map_semaphore_);
+      candidate_map_.find(sum)->second.at(rv.opt_idx.value())
+          .combos.insert(std::move(combo));
+    }
+    // else: source pair was incompatible, nothing to add to
+    return 0;
+  }
+
   CandidateRepoValue repo_value;
   repo_value.compat_src_indices = std::move(
       make_compat_source_indices(nc_cref_list, unique_name_indices, idx_pair));
@@ -279,8 +306,7 @@ int consider_candidate(int sum, const NameCountCRefList& nc_cref_list,
   if (rv.compat_src_indices.empty()) {
     cc.num_incompat++;
   } else {
-    // TODO: util::append
-    add_candidate(sum, NameCount::makeString(nc1.name, nc2.name),
+    rv.opt_idx = add_candidate(sum, std::move(combo),
         std::cref(rv.compat_src_indices));
   }
   return 0;

--- a/src/native-modules/experiment/candidates.cpp
+++ b/src/native-modules/experiment/candidates.cpp
@@ -48,7 +48,7 @@ private:
 
 // globals
 
-constexpr const int kMaxRepos = 20;
+constexpr const int kMaxRepos = kMaxSources;
 std::vector<CandidateRepo> candidate_repos_(kMaxRepos);
 std::binary_semaphore candidate_repos_semaphore_{1};
 

--- a/src/native-modules/experiment/clue-manager.cpp
+++ b/src/native-modules/experiment/clue-manager.cpp
@@ -173,7 +173,7 @@ auto get_name_sources_map(int count) -> const NameSourcesMap& {
 }
 
 void set_name_sources_map(int count, NameSourcesMap&& name_sources_map) {
-  auto idx = count - 1;
+  const auto idx = count - 1;
   // allow sets exactly in-sequence only, or throw an exception
   assert((int)nameSourcesMaps.size() == idx);
   nameSourcesMaps.push_back(std::move(name_sources_map));

--- a/src/native-modules/experiment/clue-manager.cpp
+++ b/src/native-modules/experiment/clue-manager.cpp
@@ -101,7 +101,7 @@ void populate_unique_clue_nc_list(NameCountList& nc_list, int count) {
 
 const auto& get_unique_clue_nc_list(int count) {
   const auto idx{count - 1};
-  if ((int)uniqueClueNames_.size() <= idx) { uniqueClueNames_.resize(idx + 1); }
+  assert(idx >= 0 && idx < (int)uniqueClueNames_.size());
   auto& nc_list = uniqueClueNames_.at(idx);
   if (nc_list.empty()) {
     populate_unique_clue_nc_list(nc_list, count);
@@ -177,6 +177,7 @@ void set_name_sources_map(int count, NameSourcesMap&& name_sources_map) {
   // allow sets exactly in-sequence only, or throw an exception
   assert((int)nameSourcesMaps.size() == idx);
   nameSourcesMaps.push_back(std::move(name_sources_map));
+  uniqueClueNames_.resize(nameSourcesMaps.size());
 }
 
 bool is_known_name_count(const std::string& name, int count) {

--- a/src/native-modules/experiment/clue-manager.cpp
+++ b/src/native-modules/experiment/clue-manager.cpp
@@ -2,6 +2,7 @@
 #include <charconv>
 #include <chrono>
 #include <cmath>
+#include <mutex>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -99,9 +100,12 @@ void populate_unique_clue_nc_list(NameCountList& nc_list, int count) {
   }
 }
 
+std::mutex uniqueClueNamesMutex_;
+
 const auto& get_unique_clue_nc_list(int count) {
   const auto idx{count - 1};
   assert(idx >= 0 && idx < (int)uniqueClueNames_.size());
+  std::lock_guard lock(uniqueClueNamesMutex_);
   auto& nc_list = uniqueClueNames_.at(idx);
   if (nc_list.empty()) {
     populate_unique_clue_nc_list(nc_list, count);

--- a/src/native-modules/experiment/clue-manager.cpp
+++ b/src/native-modules/experiment/clue-manager.cpp
@@ -4,9 +4,11 @@
 #include <cmath>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 #include "clue-manager.h"
+#include "cm-hash.h"
 #include "known-sources.h"
 #include "util.h"
 #include "log.h"
@@ -35,6 +37,10 @@ std::vector<NameSourcesMap> nameSourcesMaps;
 std::vector<NameCountList> uniqueClueNames_;
 
 SourceCompatibilityList uniquePrimaryClueSrcList_;
+
+// source group IDs: names with identical SourceCompatibilityData sets share a
+// group ID. indexed by [count-1][unique_name_idx]. populated lazily.
+std::vector<std::vector<int>> source_group_ids_;
 
 // nameSourcesMap
 
@@ -117,6 +123,81 @@ const auto& get_unique_clue_nc_list(int count) {
 void ensure_primary_unique_clue_source_list() {
   if (uniquePrimaryClueSrcList_.empty()) {
     uniquePrimaryClueSrcList_ = std::move(make_unique_clue_source_list(1));
+  }
+}
+
+// source groups
+
+struct NameAndSources {
+  int unique_name_idx;
+  std::unordered_set<SourceCompatCRef> sources;
+};
+
+void build_source_group_ids(int count) {
+  const auto idx = count - 1;
+  if (idx < (int)source_group_ids_.size() && !source_group_ids_.at(idx).empty()) {
+    return;  // already built
+  }
+  source_group_ids_.resize(
+      std::max(source_group_ids_.size(), (size_t)(idx + 1)));
+
+  const auto num_names = get_num_unique_clue_names(count);
+  auto& ids = source_group_ids_.at(idx);
+  ids.resize(num_names, -1);
+
+  // Phase 1: hash each name's source set into scalar buckets
+  std::unordered_map<size_t, std::vector<NameAndSources>> buckets;
+  for (int i{}; i < num_names; ++i) {
+    const auto& name = get_unique_clue_name(count, i);
+    std::unordered_set<SourceCompatCRef> src_set;
+    size_t hash = 0;
+    KnownSources::for_each_nc_source_compat(name, count,
+        [&](const SourceCompatibilityData& src, index_t) {
+          src_set.insert(std::cref(src));
+          hash += std::hash<SourceCompatibilityData>{}(src);
+        });
+    buckets[hash].push_back({i, std::move(src_set)});
+  }
+
+  // Phase 2: within each bucket, resolve hash collisions into true
+  // equivalence classes and assign group IDs
+  int next_group_id = 0;
+  int num_shared = 0;
+  for (auto& [_, bucket] : buckets) {
+    std::vector<int> sub_group_ids;
+    std::vector<std::unordered_set<SourceCompatCRef>*> sub_reps;
+    std::vector<std::vector<int>> sub_group_indices;
+
+    for (auto& entry : bucket) {
+      bool found = false;
+      for (size_t g = 0; g < sub_reps.size(); ++g) {
+        if (entry.sources == *sub_reps[g]) {
+          sub_group_indices[g].push_back(entry.unique_name_idx);
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        sub_group_ids.push_back(next_group_id++);
+        sub_reps.push_back(&entry.sources);
+        sub_group_indices.push_back({entry.unique_name_idx});
+      }
+    }
+
+    for (size_t g = 0; g < sub_group_ids.size(); ++g) {
+      if (sub_group_indices[g].size() > 1) {
+        num_shared += int(sub_group_indices[g].size());
+      }
+      for (auto name_idx : sub_group_indices[g]) {
+        ids.at(name_idx) = sub_group_ids[g];
+      }
+    }
+  }
+
+  if (num_shared && log_level(Verbose)) {
+    std::cerr << "source groups(" << count << "): " << num_names << " names -> "
+              << next_group_id << " groups, " << num_shared
+              << " names share sources\n";
   }
 }
 
@@ -267,6 +348,11 @@ int get_unique_clue_starting_source_index(int count, int unique_name_idx) {
   return start_idx;
 }
 
+int get_source_group_id(int count, int unique_name_idx) {
+  build_source_group_ids(count);
+  return source_group_ids_.at(count - 1).at(unique_name_idx);
+}
+
 //
 // misc
 //
@@ -324,6 +410,7 @@ void reset() {
   nameSourcesMaps.clear();
   uniqueClueNames_.clear();
   uniquePrimaryClueSrcList_.clear();
+  source_group_ids_.clear();
   KnownSources::get().reset();
 }
 

--- a/src/native-modules/experiment/clue-manager.h
+++ b/src/native-modules/experiment/clue-manager.h
@@ -42,6 +42,9 @@ const std::vector<std::string>& get_nc_sources(const NameCount& nc);
 
 int get_num_unique_clue_names(int count);
 
+// source groups - names with identical SourceCompatibilityData sets share a group ID
+int get_source_group_id(int count, int unique_name_idx);
+
 const NameCount& get_unique_clue_nc(int count, int idx);
 
 const std::string& get_unique_clue_name(int count, int idx);

--- a/src/native-modules/experiment/cm-constants.h
+++ b/src/native-modules/experiment/cm-constants.h
@@ -2,6 +2,7 @@
 
 namespace cm {
 
+inline constexpr auto kMaxSources = 32;
 inline constexpr auto kMaxSourcesPerSentence = 32;
 inline constexpr auto kNumSentences = 9;
 

--- a/src/native-modules/experiment/cm-hash.h
+++ b/src/native-modules/experiment/cm-hash.h
@@ -125,3 +125,9 @@ template <> struct hash<cm::CompatSourceIndices> {
 
 } // namespace std
 
+// needed for unordered_set<SourceCompatCRef>::operator==
+namespace cm {
+inline bool operator==(SourceCompatCRef lhs, SourceCompatCRef rhs) noexcept {
+  return std::equal_to<SourceCompatibilityData>{}(lhs.get(), rhs.get());
+}
+}  // namespace cm

--- a/src/native-modules/experiment/cuda-types.h
+++ b/src/native-modules/experiment/cuda-types.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <bit>
 #include <cassert>
 #include <cmath>
 #include <cstdint>
@@ -20,7 +21,6 @@
 namespace cm {
 
 constexpr unsigned kMaxOrArgs = 20;
-constexpr auto kMaxSums = 32;
 constexpr auto kMaxSwarms = 2;                // 2 swarms
 constexpr auto kMaxStreams = kMaxSwarms * 3;  // 3 streams per swarm
 
@@ -30,6 +30,9 @@ using result_t = uint8_t;
 using index_t = uint32_t;
 using fat_index_t = uint64_t;
 using atomic64_t = unsigned long long int;
+
+static_assert(std::has_single_bit(index_t{kMaxSources}),
+    "kMaxSources must be a power of two");
 
 template <typename T> using IndexListBase = std::vector<T>;
 
@@ -46,15 +49,20 @@ struct CompatSourceIndex {
   CompatSourceIndex(int count, index_t idx) : data_(make_data(count, idx)) {}
 
   static index_t make_data(int count, index_t idx) {
-    return index_t(count) << 27 | (idx & 0x07ffffff);
+    return index_t(count) << kIndexBits | (idx & kIndexMask);
   }
 
-  constexpr auto count() const { return data_ >> 27; }
-  constexpr auto index() const { return data_ & 0x07ffffff; }
+  constexpr auto count() const { return data_ >> kIndexBits; }
+  constexpr auto index() const { return data_ & kIndexMask; }
 
   auto data() const { return data_; }
 
 private:
+  static constexpr auto kIndexTypeBits = sizeof(index_t) * 8;
+  static constexpr auto kCountBits = std::countr_zero(index_t{kMaxSources});
+  static constexpr auto kIndexBits = kIndexTypeBits - kCountBits;
+  static constexpr auto kIndexMask = (index_t{1} << kIndexBits) - 1;
+
   index_t data_;
 };
 

--- a/src/native-modules/experiment/filter-stream.cpp
+++ b/src/native-modules/experiment/filter-stream.cpp
@@ -14,7 +14,7 @@ extern __constant__ FilterStreamData::Device stream_data_[kMaxStreams];
 void FilterStreamData::Device::init(FilterStream& stream, FilterData& mfd) {
   if (!stream.host.device_initialized) {
     assert(stream.host.stream_idx() < kMaxStreams);
-    alloc_buffers(mfd, stream.cuda_stream);
+    alloc_buffers(mfd, stream.stride, stream.cuda_stream);
     copy_to_symbol(stream.host.stream_idx(), stream.cuda_stream);
     stream.host.device_initialized = true;
   }
@@ -32,10 +32,10 @@ void FilterStreamData::Device::alloc_copy_source_index_list(const Host& host,
     }
     cuda_malloc_async((void**)&src_idx_list, num_bytes, stream,
         "device.src_idx_list");
-    num_src_idx = num_host_src_idx;
-    // device members updated; need to (re)copy to symbol
-    copy_to_symbol(host.stream_idx(), stream);
   }
+  num_src_idx = num_host_src_idx;
+  // num_src_idx may shrink between sums, so always refresh constant memory.
+  copy_to_symbol(host.stream_idx(), stream);
   // copy source indices
   auto err = cudaMemcpyAsync(src_idx_list, host.src_idx_list.data(), num_bytes,
       cudaMemcpyHostToDevice, stream);
@@ -43,8 +43,9 @@ void FilterStreamData::Device::alloc_copy_source_index_list(const Host& host,
 }
 
 void FilterStreamData::Device::alloc_buffers(FilterData& mfd,
-    cudaStream_t stream) {
-  const auto [grid_size, _] = get_filter_kernel_grid_block_sizes();
+    size_t max_active_sources, cudaStream_t stream) {
+  const auto [grid_size, _] =
+      get_filter_kernel_grid_block_sizes(max_active_sources);
   if (mfd.device_xor.num_unique_variations) {
     const auto num_bytes = mfd.device_xor.num_unique_variations * grid_size
         * sizeof(index_t);

--- a/src/native-modules/experiment/filter-stream.h
+++ b/src/native-modules/experiment/filter-stream.h
@@ -27,6 +27,13 @@ struct FilterStreamData {
   struct Device {
     void init() {
       src_idx_list = nullptr;
+      xor_src_compat_uv_indices = nullptr;
+      or_xor_compat_uv_indices = nullptr;
+#ifdef VARIATIONS_RESULTS
+      variations_compat_results = nullptr;
+      num_variations_results_per_block = 0;
+#endif
+      or_src_bits_compat_results = nullptr;
       num_src_idx = 0;
     }
     void init(FilterStream& stream, FilterData& mfd);
@@ -61,7 +68,8 @@ struct FilterStreamData {
     index_t num_src_idx;
 
   private:
-    void alloc_buffers(FilterData& fd, cudaStream_t stream);
+    void alloc_buffers(FilterData& fd, size_t max_active_sources,
+        cudaStream_t stream);
     void copy_to_symbol(index_t idx, cudaStream_t stream);
   };  // struct Device
 };  // struct FilterStreamData

--- a/src/native-modules/experiment/filter-support.cpp
+++ b/src/native-modules/experiment/filter-support.cpp
@@ -76,7 +76,7 @@ private:
 
   std::mutex mutex_;
   std::condition_variable cv_;
-  std::bitset<kMaxSums> bits_;
+  std::bitset<kMaxSources> bits_;
 };
 
 CompletionTracker source_copy_tracker_;

--- a/src/native-modules/experiment/filter-support.cpp
+++ b/src/native-modules/experiment/filter-support.cpp
@@ -500,8 +500,6 @@ filter_sources(FilterSwarm& swarm, const FilterParams& params,
 
   // TODO: FilterStreamData::Host, resize_results()
   std::vector<result_t> results(num_results);
-  // TODO: this is dumb
-  swarm.init(stride);
   auto t = util::Timer::start_timer();
   const auto [num_processed, num_compat] =  //
       run_concurrent_filter_kernels(params.sum, swarm, params.threads_per_block,
@@ -655,6 +653,8 @@ filter_task_result_t filter_task(FilterData& mfd, FilterParams params) {
   auto& swarm = swarm_pool_.acquire();
   const auto num_streams = params.num_streams ? params.num_streams : 1;
   swarm.ensure_streams(num_streams); // set_num_streams might be better
+  const auto stride = params.stride ? params.stride : int(idx_lists.size());
+  swarm.init(stride);
 
   const auto& stream = swarm.at(0);
   stream.copy_start.record(stream.cuda_stream);

--- a/src/native-modules/experiment/filter.cu
+++ b/src/native-modules/experiment/filter.cu
@@ -778,16 +778,15 @@ __global__ void filter_kernel(result_t* RESTRICT results, index_t swarm_idx,
 
 }  // anonymous namespace
 
-std::pair<int, int> get_filter_kernel_grid_block_sizes(size_t active_sources) {
+std::pair<int, int> get_filter_kernel_grid_block_sizes(size_t num_sources) {
   // hard-code 64 due to cub::BlockScan
   const auto block_size = 64;  // threads_per_block ? threads_per_block : 64;
   const auto max_threads_per_sm = CudaDevice::get().max_threads_per_sm();
   const auto blocks_per_sm = max_threads_per_sm / block_size;
   assert(blocks_per_sm * block_size == max_threads_per_sm);
   const auto max_grid_size = CudaDevice::get().num_sm() * blocks_per_sm;
-  const auto grid_size = active_sources
-      ? std::max(1, std::min<int>(max_grid_size, int(active_sources)))
-      : max_grid_size;
+  assert(num_sources > 0);
+  const auto grid_size = std::min<int>(max_grid_size, int(num_sources));
   return std::make_pair(grid_size, block_size);
 }
 
@@ -808,6 +807,7 @@ void run_filter_kernel(int /*threads_per_block*/, index_t swarm_idx,
     FilterStream& stream, result_t* device_results) {
   stream.is_running = true;
   stream.increment_sequence_num();
+  assert(!stream.host.src_idx_list.empty());
   const auto [grid_size, block_size] =
       get_filter_kernel_grid_block_sizes(stream.host.src_idx_list.size());
   // xor_results could probably be moved to global

--- a/src/native-modules/experiment/filter.cu
+++ b/src/native-modules/experiment/filter.cu
@@ -778,13 +778,16 @@ __global__ void filter_kernel(result_t* RESTRICT results, index_t swarm_idx,
 
 }  // anonymous namespace
 
-std::pair<int, int> get_filter_kernel_grid_block_sizes() {
+std::pair<int, int> get_filter_kernel_grid_block_sizes(size_t active_sources) {
   // hard-code 64 due to cub::BlockScan
   const auto block_size = 64;  // threads_per_block ? threads_per_block : 64;
   const auto max_threads_per_sm = CudaDevice::get().max_threads_per_sm();
   const auto blocks_per_sm = max_threads_per_sm / block_size;
   assert(blocks_per_sm * block_size == max_threads_per_sm);
-  const auto grid_size = CudaDevice::get().num_sm() * blocks_per_sm;
+  const auto max_grid_size = CudaDevice::get().num_sm() * blocks_per_sm;
+  const auto grid_size = active_sources
+      ? std::max(1, std::min<int>(max_grid_size, int(active_sources)))
+      : max_grid_size;
   return std::make_pair(grid_size, block_size);
 }
 
@@ -805,7 +808,8 @@ void run_filter_kernel(int /*threads_per_block*/, index_t swarm_idx,
     FilterStream& stream, result_t* device_results) {
   stream.is_running = true;
   stream.increment_sequence_num();
-  const auto [grid_size, block_size] = get_filter_kernel_grid_block_sizes();
+  const auto [grid_size, block_size] =
+      get_filter_kernel_grid_block_sizes(stream.host.src_idx_list.size());
   // xor_results could probably be moved to global
   const auto shared_bytes = kSharedIndexCount
           * sizeof(shared_index_t)            // indices

--- a/src/native-modules/experiment/filter.cu
+++ b/src/native-modules/experiment/filter.cu
@@ -17,7 +17,7 @@ __constant__ FilterData::DeviceXor xor_data;
 __constant__ FilterData::DeviceOr or_data;
 __constant__ FilterSwarmData::Device swarm_data_[kMaxSwarms];
 __constant__ FilterStreamData::Device stream_data_[kMaxStreams];
-__constant__ SourceCompatibilityData* sources_data[kMaxSums];
+__constant__ SourceCompatibilityData* sources_data[kMaxSources];
 
 #if defined(DEBUG_XOR_COUNTS) || defined(DEBUG_OR_COUNTS)
 __device__ atomic64_t count_xor_src_considered = 0;

--- a/src/native-modules/experiment/filter.cu
+++ b/src/native-modules/experiment/filter.cu
@@ -807,7 +807,6 @@ void run_filter_kernel(int /*threads_per_block*/, index_t swarm_idx,
     FilterStream& stream, result_t* device_results) {
   stream.is_running = true;
   stream.increment_sequence_num();
-  assert(!stream.host.src_idx_list.empty());
   const auto [grid_size, block_size] =
       get_filter_kernel_grid_block_sizes(stream.host.src_idx_list.size());
   // xor_results could probably be moved to global

--- a/src/native-modules/experiment/filter.cuh
+++ b/src/native-modules/experiment/filter.cuh
@@ -12,7 +12,7 @@ struct FilterStream;
 class SourceCompatibilityData;
 struct SourceDescriptorPair;
 
-extern __constant__ SourceCompatibilityData* sources_data[kMaxSums];
+extern __constant__ SourceCompatibilityData* sources_data[kMaxSources];
 
 void run_get_compatible_sources_kernel(
     const CompatSourceIndices* device_src_indices, size_t num_src_indices,

--- a/src/native-modules/experiment/filter.cuh
+++ b/src/native-modules/experiment/filter.cuh
@@ -20,7 +20,8 @@ void run_get_compatible_sources_kernel(
     size_t num_src_desc_pairs, result_t* device_resultsy,
     cudaStream_t sync_stream, cudaStream_t stream);
 
-std::pair<int, int> get_filter_kernel_grid_block_sizes();
+std::pair<int, int> get_filter_kernel_grid_block_sizes(
+    size_t active_sources = 0);
 
 void copy_filter_data_to_symbols(const FilterData& mfd, cudaStream_t stream);
 
@@ -42,4 +43,3 @@ inline constexpr void dump_compat_src_indices(
 #endif
 
 }  // namespace cm
-

--- a/src/native-modules/experiment/filter.cuh
+++ b/src/native-modules/experiment/filter.cuh
@@ -20,8 +20,7 @@ void run_get_compatible_sources_kernel(
     size_t num_src_desc_pairs, result_t* device_resultsy,
     cudaStream_t sync_stream, cudaStream_t stream);
 
-std::pair<int, int> get_filter_kernel_grid_block_sizes(
-    size_t active_sources = 0);
+std::pair<int, int> get_filter_kernel_grid_block_sizes(size_t num_sources);
 
 void copy_filter_data_to_symbols(const FilterData& mfd, cudaStream_t stream);
 

--- a/src/tools/clues.js
+++ b/src/tools/clues.js
@@ -502,7 +502,9 @@ async function main () {
         options.count_lo = countRange[0];
         options.count_hi = countRange.length > 1 ? countRange[1] : countRange[0];
         let generate_max = options.count_hi;
-        options.load_max = Math.min(options.load_max, generate_max - 1);
+        if (!options.xor && !options.or) {
+            options.load_max = Math.min(options.load_max, generate_max - 1);
+        }
     }
     console.error(`load_max(${options.load_max})`);
 

--- a/src/tools/todo
+++ b/src/tools/todo
@@ -1,3 +1,5 @@
+++ older stuff below
+
 * passing shared variable as param: xor_chunk_idx
 
 * results -> FilterStreamData
@@ -9,7 +11,10 @@
 * ok something weird with --max-sources. it actually changes the number of valid results,
   for a -c2 for example. it also seems to, naturally(?), increase the number of XOR sources.
   so really, i need to:
-  * figure out *why* this is affecting valid result count.
+  * PROBABLY SOLVED - figure out *why* this is affecting valid result count.
+    - because max_sources was all fucked up and was probably overriding COUNT_LO. it was a mess.
+      but i should try it again with the new args.load_max change.
+  
   * set --max-sources to (M-1) for -cM, and (N-1) for -cM,N, if not otherwise specified,
     because there is no reason to generate a large number of XOR sources that shouldn't
     be used and shouldn't impact results (afaik).
@@ -17,8 +22,8 @@
       --xor sources themselves, like, "21", which requires --max-sources 13. but maybe
       there is some way to shortcut this, such that rather than searching *all* sources
       up to some --max, i just search for all instances of "21" (specified sources).
-  * maybe think about how i might support -cLARGE with --max-sources *smaller* than
-    LARGE-1. not a priority though, i should't really be playing with those sizes.
+  * SOLVED - maybe think about how i might support -cLARGE with --max-sources *smaller* than
+      LARGE-1. not a priority though, i should't really be playing with those sizes.
 
 * "Source" is overloaded. like the "Source" (namespace?) in combo-maker.h. what's
    a better name for it?
@@ -44,6 +49,12 @@
     * i think it's in the stream now. in_place still broke I think.
   * fixed a bug in compact_sums_to_indices wrt last_scan_result that needs to be fixed
     here as well. left a comment in code.
+  * comment from a commit:
+      Setting swarm_pool to only 1 entry fixes a lot of things related to stability
+      (particularly spurious device memory-access errors) including making me realize
+      that compact_uv_indices_in_place may actually be working just fine, but the
+      shared variations_indices and compat_indices buffer pointers (copied from MFD)
+      might be messing it (and other things) up
     
 * unique_sources branch implementation issues:
   * validation failures. possibly because hash/equal_to of SourceData is wrong (doesn't
@@ -67,6 +78,42 @@
   *is*, ostensibly. But it doesn't appear to be working that way; seems I lost the plot
   at some point. Or my assumptions about what the "key" of the candidate_repo map should
   be is wrong. I mean, it's potentially synonyms all the way down right?
+
+  Claude plan: dedupe-candidate-sources, resume session: dedupe-candidate-sources
+
+         That's a really important distinction. Let me make sure I understand the three levels:
+
+         1. Synonyms — explicit synonym relationships. Partial fix only.
+         2. Same source names — different clue names that happen to have the same source
+            CSV strings at a given count. Captures more, but still incomplete because...
+         3. Same SourceCompatibilityData — the actual resolved source data after recursively
+            expanding source names down to primary clues. Two clue names with completely
+            different source names could still produce identical SourceCompatibilityData
+            if their sources' sources are synonyms (or otherwise equivalent).
+            This is "synonyms all the way down."
+
+         And your key question: does the candidate pipeline even have access to SourceCompatibilityData
+         at the point where dedup would matter, or does it only work with packed SourceIndices?
+
+         Let me check what for_each_nc_source_compat actually iterates over and where
+         SourceCompatibilityData lives relative to the indices.
+
+         This is key. for_each_nc_source_compat iterates through SourceCompatibilityData objects — 
+         it does drill down to that level. Each callback in  make_compat_source_indices receives
+         a const SourceCompatibilityData& and an index_t idx. But then it only stores the packed
+         index (CompatSourceIndex{count, start_idx + idx}) into compat_src_indices. The actual
+         SourceCompatibilityData is used transiently for the isXorCompatibleWith test and then
+         discarded.
+
+         So to your point: candidates operates through SourceCompatibilityData (for the XOR-compat
+         check) but only stores SourceIndices. The indices are positions into a flat ordering of
+         sources for a given name+count. Two different names that happen to resolve to the same
+         SourceCompatibilityData objects would get different indices (because the index space is
+         per-name), even though the underlying data is identical.
+
+         That means dedup at level 3 can't just compare indices — the indices would differ. You'd
+         need to compare the actual SourceCompatibilityData objects.
+
 
 * move all the clock/count stuff to a separate file
 


### PR DESCRIPTION
## Summary
- deduplicate candidates that share identical source combinations by assigning source group IDs
- thread the dedupe handling through combo generation and clue manager/native candidate paths
- keep the existing CUDA/filter fixes on this branch

## Notes
- the worktree still has unrelated local changes outside this branch diff; they are not part of the pushed commits

## Verification
- branch pushed to origin/dedupe-candidates
- diff reviewed against origin/master